### PR TITLE
21/01 claudia grid on/off

### DIFF
--- a/app/src/main/java/com/example/wheelcam/MainActivity.java
+++ b/app/src/main/java/com/example/wheelcam/MainActivity.java
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
     private FloatingActionButton startVideo_Btn;
     private FloatingActionButton stopVideo_Btn;
     private ImageButton arrowBtnR, arrowBtnUp, arrowBtnDown, arrowBtnL;
-    private Button bluetooth_Btn, center_Btn, moveDoneBtn, orientBtn, modeDoneBtn, flipBtn, galleryBtn, settingsBtn, flash_Btn;
+    private Button bluetooth_Btn, scanCenter_Btn, moveDoneBtn, orientBtn, modeDoneBtn, flipBtn, galleryBtn, /*settingsBtn,*/ flash_Btn;
     private Button grid_A, grid_B, grid_C, grid_D, grid_E, grid_F, grid_G, grid_H, grid_I;
     private Button zoom05_Btn, zoom1_Btn, zoom15_Btn, zoom2_Btn, zoom3_Btn;
     private Button video_Btn, photo_Btn;
@@ -206,13 +206,14 @@ public class MainActivity extends AppCompatActivity {
         highlightButton(currentButtonIndex);
         highlightHandler.postDelayed(highlightRunnable, 3000);
     }
+
     private void initialiseHighlightableButtons() {
         highlightableButtons = new ArrayList<>();
         highlightableButtons.add((View) findViewById(R.id.flashBtn));
-        highlightableButtons.add((View) findViewById(R.id.centerBtn));
+        highlightableButtons.add((View) findViewById(R.id.scanCenterBtn));
         highlightableButtons.add((View) findViewById(R.id.rotateBtn));
         highlightableButtons.add((View) findViewById(R.id.bluetooth));
-        highlightableButtons.add((View) findViewById(R.id.settingsBtn));
+        //highlightableButtons.add((View) findViewById(R.id.settingsBtn));
         highlightableButtons.add((View) findViewById(R.id.gridA));
         highlightableButtons.add((View) findViewById(R.id.gridB));
         highlightableButtons.add((View) findViewById(R.id.gridC));
@@ -320,9 +321,9 @@ public class MainActivity extends AppCompatActivity {
         arrowBtnR = findViewById(R.id.arrowBtn_Right);
       // grid_Btn = findViewById(R.id.gridBtn);
         bluetooth_Btn = findViewById(R.id.bluetooth);
-        center_Btn = findViewById(R.id.centerBtn);
+        scanCenter_Btn = findViewById(R.id.scanCenterBtn);
         flash_Btn = findViewById(R.id.flashBtn);
-        settingsBtn = findViewById(R.id.settingsBtn);
+        //settingsBtn = findViewById(R.id.settingsBtn);
         directionLO = findViewById(R.id.directionLayout);
         levelLO = findViewById(R.id.levelLayout);
         orientLO = findViewById(R.id.orientationLayout);
@@ -665,7 +666,7 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
-        center_Btn.setOnClickListener(new View.OnClickListener() {
+        scanCenter_Btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(MainActivity.this, OldMainActivity.class);

--- a/app/src/main/java/com/example/wheelcam/MainActivity.java
+++ b/app/src/main/java/com/example/wheelcam/MainActivity.java
@@ -177,6 +177,8 @@ public class MainActivity extends AppCompatActivity {
         initialiseUI();
         setUI();
 
+        gridLO.setVisibility(View.GONE);
+
         if (isFinishing()){
             if (bluetoothSocket!= null) {
                 try {
@@ -629,15 +631,37 @@ public class MainActivity extends AppCompatActivity {
         gridCenter_Btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (gridCenter_Btn.getText() == "Grid Center"){
-                    gridCenter_Btn.setText("grid off");
+                if ("Grid Center".equals(gridCenter_Btn.getText().toString())) {
+                    gridCenter_Btn.setText("Grid off");
                     gridLO.setVisibility(View.VISIBLE);
-                }else {
+
+                    modeLO.setVisibility(View.GONE);
+                    flash_Btn.setVisibility(View.GONE);
+                    scanCenter_Btn.setVisibility(View.GONE);
+                    orientBtn.setVisibility(View.GONE);
+                    bluetooth_Btn.setVisibility(View.GONE);
+                    galleryBtn.setVisibility(View.GONE);
+                    flipBtn.setVisibility(View.GONE);
+                    zoomLO.setVisibility(View.GONE);
+
+
+
+                } else {
                     gridCenter_Btn.setText("Grid Center");
                     gridLO.setVisibility(View.GONE);
+
+                    modeLO.setVisibility(View.VISIBLE);
+                    flash_Btn.setVisibility(View.VISIBLE);
+                    scanCenter_Btn.setVisibility(View.VISIBLE);
+                    orientBtn.setVisibility(View.VISIBLE);
+                    bluetooth_Btn.setVisibility(View.VISIBLE);
+                    galleryBtn.setVisibility(View.VISIBLE);
+                    flipBtn.setVisibility(View.VISIBLE);
+                    zoomLO.setVisibility(View.VISIBLE);
                 }
             }
         });
+
 
         flipBtn.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/example/wheelcam/MainActivity.java
+++ b/app/src/main/java/com/example/wheelcam/MainActivity.java
@@ -78,18 +78,18 @@ public class MainActivity extends AppCompatActivity {
         // reset isrotating
         isRotating = false;
 
-        highlightHandler.removeCallbacks(highlightRunnable);
+        //highlightHandler.removeCallbacks(highlightRunnable);
 
-        initialiseHighlightableButtons();
+        //initialiseHighlightableButtons();
 
 
         // reset currentButtonIndex
         currentButtonIndex = 0;
-        highlightButton(currentButtonIndex);
-        highlightHandler.postDelayed(highlightRunnable, 3000);
+        //highlightButton(currentButtonIndex);
+        //highlightHandler.postDelayed(highlightRunnable, 3000);
     }
 
-    private Runnable highlightRunnable = new Runnable() {
+    /*private Runnable highlightRunnable = new Runnable() {
         @Override
         public void run() {
             // check if rotating
@@ -104,10 +104,10 @@ public class MainActivity extends AppCompatActivity {
             Log.d(TAG, "New currentButtonIndex: " + currentButtonIndex);
             highlightHandler.postDelayed(this, 3000);
         }
-    };
+    };*/
 
-    private ArrayList<View> highlightableButtons;
-    private Handler highlightHandler = new Handler();
+    //private ArrayList<View> highlightableButtons;
+    //private Handler highlightHandler = new Handler();
     private int currentButtonIndex = 0;
     private CameraControl cameraControl;
     private VideoCapture videoCapture;
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
     private FloatingActionButton startVideo_Btn;
     private FloatingActionButton stopVideo_Btn;
     private ImageButton arrowBtnR, arrowBtnUp, arrowBtnDown, arrowBtnL;
-    private Button bluetooth_Btn, scanCenter_Btn, moveDoneBtn, orientBtn, modeDoneBtn, flipBtn, galleryBtn, /*settingsBtn,*/ flash_Btn;
+    private Button bluetooth_Btn, scanCenter_Btn, gridCenter_Btn, moveDoneBtn, orientBtn, modeDoneBtn, flipBtn, galleryBtn, /*settingsBtn,*/ flash_Btn;
     private Button grid_A, grid_B, grid_C, grid_D, grid_E, grid_F, grid_G, grid_H, grid_I;
     private Button zoom05_Btn, zoom1_Btn, zoom15_Btn, zoom2_Btn, zoom3_Btn;
     private Button video_Btn, photo_Btn;
@@ -159,8 +159,9 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-         initialiseHighlightableButtons();
-         highlightHandler.postDelayed(highlightRunnable, 3000);
+
+        //initialiseHighlightableButtons();
+        //highlightHandler.postDelayed(highlightRunnable, 3000);
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
         if (!checkPermission())
@@ -195,7 +196,7 @@ public class MainActivity extends AppCompatActivity {
             e.printStackTrace();
         }
     }
-    private void updateHighlightableButtonsForRotation() {
+    /*private void updateHighlightableButtonsForRotation() {
         Log.d(TAG, "Entering rotation mode");
         highlightHandler.removeCallbacks(highlightRunnable);
         highlightableButtons.clear();
@@ -205,12 +206,13 @@ public class MainActivity extends AppCompatActivity {
         currentButtonIndex = 0;
         highlightButton(currentButtonIndex);
         highlightHandler.postDelayed(highlightRunnable, 3000);
-    }
+    }*/
 
-    private void initialiseHighlightableButtons() {
+    /*private void initialiseHighlightableButtons() {
         highlightableButtons = new ArrayList<>();
         highlightableButtons.add((View) findViewById(R.id.flashBtn));
         highlightableButtons.add((View) findViewById(R.id.scanCenterBtn));
+        highlightableButtons.add((View) findViewById(R.id.gridCenterBtn));
         highlightableButtons.add((View) findViewById(R.id.rotateBtn));
         highlightableButtons.add((View) findViewById(R.id.bluetooth));
         //highlightableButtons.add((View) findViewById(R.id.settingsBtn));
@@ -235,8 +237,8 @@ public class MainActivity extends AppCompatActivity {
         highlightableButtons.add((View) findViewById(R.id.flipBtn));
         Log.d(TAG, "Total number of highlightable buttons: " + highlightableButtons.size());
         //add more buttons
-    }
-    private void highlightButton(int index) {
+    }*/
+    /*private void highlightButton(int index) {
         Log.d(TAG, "Highlighting button at index: " + index);
         for (int i = 0; i < highlightableButtons.size(); i++) {
             View view = highlightableButtons.get(i);
@@ -252,10 +254,10 @@ public class MainActivity extends AppCompatActivity {
                 Log.d(TAG, "Button at index " + i + " cleared animation.");
             }
         }
-    }
+    }*/
 
 
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
+    /*public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_VOLUME_UP) {
 
             int indexToSelect = currentButtonIndex;
@@ -269,9 +271,9 @@ public class MainActivity extends AppCompatActivity {
             return true;
         }
         return super.onKeyDown(keyCode, event);
-    }
+    }*/
 
-    private void selectHighlightedButton(int indexToSelect) {
+    /*private void selectHighlightedButton(int indexToSelect) {
 
         View selectedView = highlightableButtons.get(indexToSelect);
 
@@ -279,7 +281,7 @@ public class MainActivity extends AppCompatActivity {
             Button selectedButton = (Button) selectedView;
             selectedButton.performClick();
         }
-    }
+    }*/
 
 
     @Override
@@ -287,14 +289,14 @@ public class MainActivity extends AppCompatActivity {
     protected void onResume() {
         checkBtEnabled();
         super.onResume();
-        highlightHandler.postDelayed(highlightRunnable, 3000);
+        // highlightHandler.postDelayed(highlightRunnable, 3000);
         if (cameraProvider != null) {
             startCameraX(cameraProvider);
         }
     }
     protected void onPause() {
         super.onPause();
-        highlightHandler.removeCallbacks(highlightRunnable);
+        //highlightHandler.removeCallbacks(highlightRunnable);
     }
 
     public boolean checkBtEnabled() {
@@ -319,9 +321,9 @@ public class MainActivity extends AppCompatActivity {
         arrowBtnUp = findViewById(R.id.arrowBtn_Up);
         arrowBtnDown = findViewById(R.id.arrowBtn_Down);
         arrowBtnR = findViewById(R.id.arrowBtn_Right);
-      // grid_Btn = findViewById(R.id.gridBtn);
         bluetooth_Btn = findViewById(R.id.bluetooth);
         scanCenter_Btn = findViewById(R.id.scanCenterBtn);
+        gridCenter_Btn = findViewById(R.id.gridCenterBtn);
         flash_Btn = findViewById(R.id.flashBtn);
         //settingsBtn = findViewById(R.id.settingsBtn);
         directionLO = findViewById(R.id.directionLayout);
@@ -341,7 +343,7 @@ public class MainActivity extends AppCompatActivity {
         clkwiseBtn = findViewById(R.id.clockwiseBtn);
         antiClkBtn = findViewById(R.id.anticlockwiseBtn);
         gridLO = findViewById(R.id.gridLayout);
-       // grid_Btn.setText("grid on")
+        //gridCenter_Btn.setText("grid on");
         flipBtn = findViewById(R.id.flipBtn);
         galleryBtn = findViewById(R.id.galleryBtn);
         grid_A = findViewById(R.id.gridA);
@@ -534,11 +536,11 @@ public class MainActivity extends AppCompatActivity {
 
                 orientLO.setVisibility(View.VISIBLE);
                 controlCenter.setBtnClicked("ROTATE");
-                updateHighlightableButtonsForRotation();
+                //updateHighlightableButtonsForRotation();
                 currentButtonIndex = 0;
-                highlightButton(currentButtonIndex);
-                highlightHandler.removeCallbacks(highlightRunnable);
-                highlightHandler.postDelayed(highlightRunnable, 3000);
+                //highlightButton(currentButtonIndex);
+                //highlightHandler.removeCallbacks(highlightRunnable);
+                //highlightHandler.postDelayed(highlightRunnable, 3000);
             }
         });
 
@@ -624,18 +626,18 @@ public class MainActivity extends AppCompatActivity {
 
             }
         });
-     /*   grid_Btn.setOnClickListener(new View.OnClickListener() {
+        gridCenter_Btn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (grid_Btn.getText() == "grid on"){
-                    grid_Btn.setText("grid off");
+                if (gridCenter_Btn.getText() == "Grid Center"){
+                    gridCenter_Btn.setText("grid off");
                     gridLO.setVisibility(View.VISIBLE);
                 }else {
-                    grid_Btn.setText("grid on");
+                    gridCenter_Btn.setText("Grid Center");
                     gridLO.setVisibility(View.GONE);
                 }
             }
-        }); no longer needed*/
+        });
 
         flipBtn.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/com/example/wheelcam/MainActivity.java
+++ b/app/src/main/java/com/example/wheelcam/MainActivity.java
@@ -526,6 +526,14 @@ public class MainActivity extends AppCompatActivity {
                 zoomLO.setVisibility(View.VISIBLE);
                 modeLO.setVisibility(View.VISIBLE);
                 levelLO.setVisibility(View.GONE);
+                flash_Btn.setVisibility(View.VISIBLE);
+                scanCenter_Btn.setVisibility(View.VISIBLE);
+                bluetooth_Btn.setVisibility(View.VISIBLE);
+                gridCenter_Btn.setVisibility(View.VISIBLE);
+                orientBtn.setVisibility(View.VISIBLE);
+                galleryBtn.setVisibility(View.VISIBLE);
+                flipBtn.setVisibility(View.VISIBLE);
+                modeLO.setVisibility(View.VISIBLE);
             }
         });
 
@@ -535,9 +543,18 @@ public class MainActivity extends AppCompatActivity {
                 //directionLO.setVisibility(View.GONE);
                 zoomLO.setVisibility(View.GONE);
                 modeLO.setVisibility(View.GONE);
+                flash_Btn.setVisibility(View.GONE);
+                scanCenter_Btn.setVisibility(View.GONE);
+                bluetooth_Btn.setVisibility(View.GONE);
+                gridCenter_Btn.setVisibility(View.GONE);
+                orientBtn.setVisibility(View.GONE);
+                galleryBtn.setVisibility(View.GONE);
+                flipBtn.setVisibility(View.GONE);
+                modeLO.setVisibility(View.GONE);
 
                 orientLO.setVisibility(View.VISIBLE);
                 controlCenter.setBtnClicked("ROTATE");
+
                 //updateHighlightableButtonsForRotation();
                 currentButtonIndex = 0;
                 //highlightButton(currentButtonIndex);
@@ -554,6 +571,15 @@ public class MainActivity extends AppCompatActivity {
                 zoomLO.setVisibility(View.VISIBLE);
                 modeLO.setVisibility(View.VISIBLE);
                 orientLO.setVisibility(View.GONE);
+
+                flash_Btn.setVisibility(View.VISIBLE);
+                scanCenter_Btn.setVisibility(View.VISIBLE);
+                bluetooth_Btn.setVisibility(View.VISIBLE);
+                gridCenter_Btn.setVisibility(View.VISIBLE);
+                orientBtn.setVisibility(View.VISIBLE);
+                galleryBtn.setVisibility(View.VISIBLE);
+                flipBtn.setVisibility(View.VISIBLE);
+                modeLO.setVisibility(View.VISIBLE);
             }
         });
 
@@ -614,6 +640,15 @@ public class MainActivity extends AppCompatActivity {
                 orientLO.setVisibility(View.GONE);
                 completeRotation();
 
+                flash_Btn.setVisibility(View.VISIBLE);
+                scanCenter_Btn.setVisibility(View.VISIBLE);
+                bluetooth_Btn.setVisibility(View.VISIBLE);
+                gridCenter_Btn.setVisibility(View.VISIBLE);
+                orientBtn.setVisibility(View.VISIBLE);
+                galleryBtn.setVisibility(View.VISIBLE);
+                flipBtn.setVisibility(View.VISIBLE);
+                modeLO.setVisibility(View.VISIBLE);
+
             }
         });
         antiClkBtn.setOnClickListener(new View.OnClickListener() {
@@ -625,6 +660,15 @@ public class MainActivity extends AppCompatActivity {
                 modeLO.setVisibility(View.VISIBLE);
                 orientLO.setVisibility(View.GONE);
                 completeRotation();
+
+                flash_Btn.setVisibility(View.VISIBLE);
+                scanCenter_Btn.setVisibility(View.VISIBLE);
+                bluetooth_Btn.setVisibility(View.VISIBLE);
+                gridCenter_Btn.setVisibility(View.VISIBLE);
+                orientBtn.setVisibility(View.VISIBLE);
+                galleryBtn.setVisibility(View.VISIBLE);
+                flipBtn.setVisibility(View.VISIBLE);
+                modeLO.setVisibility(View.VISIBLE);
 
             }
         });

--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -8,9 +8,10 @@
     <LinearLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="70dp"
         android:layout_alignParentEnd="true"
-        android:background="@color/jade_dark">
+        android:background="@color/jade_dark"
+        >
 
         <Button
             android:id="@+id/flashBtn"
@@ -18,26 +19,23 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:background="@drawable/button_selector"
-            android:layout_marginTop="10dp"
+
             android:drawableTop="@drawable/ic_flash_off"
             android:text="Flash"
             android:textColor="@color/mint"
             android:textSize="12dp"
             android:contentDescription="Flash"/>
-
         <Button
-            android:id="@+id/centerBtn"
+            android:id="@+id/scanCenterBtn"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
             android:layout_weight="1"
             android:background="@drawable/button_selector"
             android:drawableTop="@drawable/ic_center"
             android:textSize="11dp"
             android:textColor="@color/mint"
-            android:text="Center"
-            android:contentDescription="Center" />
-
+            android:text="Scan Center"
+            android:contentDescription="Scan Center Mode" />
         <!--<Button
             android:id="@+id/zoomBtn"
             android:layout_width="wrap_content"
@@ -50,22 +48,31 @@
             android:textSize="12dp" />
             -->
         <Button
+            android:id="@+id/gridCenterBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="@drawable/button_selector"
+            android:drawableTop="@drawable/ic_grid"
+            android:text="Grid Center"
+            android:textColor="@color/mint"
+            android:textSize="12dp"
+            android:contentDescription="Grid Center Mode"/>
+        <Button
             android:id="@+id/rotateBtn"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
+
             android:background="@drawable/button_selector"
             android:drawableTop="@drawable/ic_screen_rotate"
             android:textSize="11dp"
             android:textColor="@color/mint"
             android:text="rotate"
             android:contentDescription="Rotate" />
-
         <Button
             android:id="@+id/bluetooth"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
             android:layout_weight="1"
             android:background="@drawable/button_selector"
             android:drawableTop="@drawable/ic_bluetooth_disabled"
@@ -74,20 +81,7 @@
             android:textSize="12dp"
             android:contentDescription="Bluetooth"/>
 
-        <Button
-            android:id="@+id/settingsBtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
-            android:layout_weight="1"
-            android:background="@drawable/button_selector"
-            android:drawableTop="@drawable/ic_settings"
-            android:text="Settings"
-            android:textColor="@color/mint"
-            android:textSize="8dp"
-            android:contentDescription="Settings"/>
-
-    </LinearLayout>
+    </LinearLayout> <!--End of top bar-->
 
     <androidx.camera.view.PreviewView
         android:id="@+id/previewView"
@@ -109,7 +103,7 @@
             android:src="@drawable/ic_cross_with_border"
             android:layout_gravity="center"/>
 
-    </LinearLayout>
+    </LinearLayout> <!--End of centerLO-->
     <LinearLayout
         android:id="@+id/gridLayout"
         android:layout_width="match_parent"
@@ -267,15 +261,14 @@
                 android:contentDescription="Grid I"/>
         </LinearLayout>
 
-
-    </LinearLayout>
+    </LinearLayout> <!--End of grid Layout-->
     <LinearLayout
         android:id="@+id/zoomLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
-        android:layout_alignBottom="@+id/gridLayout"
+        android:layout_alignBottom="@+id/centerLayout"
         android:orientation="horizontal"
         android:gravity="center">
         <Button
@@ -288,7 +281,6 @@
             android:background="@drawable/button_selector"
             android:contentDescription="Zoom .05"
             />
-
         <Button
             android:id="@+id/zoom1_Btn"
             android:layout_width="80dp"
@@ -330,17 +322,16 @@
             android:background="@drawable/button_selector"
             android:contentDescription="Zoom 3"
             />
-    </LinearLayout>
+    </LinearLayout> <!-- End of zoom layout-->
 
     <LinearLayout
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"
-        android:layout_height="140dp"
+        android:layout_height="130dp"
         android:layout_alignBottom="@+id/previewView"
         android:background="@color/black_halftrans"
-        android:orientation="vertical">
-
-
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/centerLayout">
         <LinearLayout
             android:id="@+id/directionLayout"
             android:layout_width="wrap_content"
@@ -392,17 +383,17 @@
                 android:contentDescription="Right" />
 
 
-        </LinearLayout>
-
+        </LinearLayout> <!--End of direction layout. we are not using this-->
         <LinearLayout
             android:id="@+id/modeLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="1dp"
-            android:layout_marginBottom="7dp"
-            android:layout_weight="1"
-            android:orientation="horizontal">
+
+            android:orientation="horizontal"
+            app:layout_constraintTop_toTopOf="@id/zoomLayout"
+            app:layout_constraintBottom_toTopOf="@id/bottomCaptureLayout"
+            >
 
             <Button
                 android:id="@+id/video_Btn"
@@ -425,7 +416,7 @@
                 android:layout_marginStart="15dp"
                 android:contentDescription="Photo Mode"
                 />
-        </LinearLayout>
+        </LinearLayout> <!--Enf od mode (PHOTO/VIDEO layout)-->
 
         <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
         We can later use this space to set the recording time -->
@@ -435,7 +426,6 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginTop="1dp"
-            android:layout_marginBottom="7dp"
             android:layout_weight="1"
             android:orientation="horizontal">
             <Button
@@ -523,7 +513,8 @@
             android:layout_marginBottom="5dp"
             android:layout_weight="1"
             android:orientation="horizontal"
-            android:visibility="gone">
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@id/bottomBar">
 
             <TextView
                 android:id="@+id/modeTV"
@@ -574,6 +565,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/bottomCaptureLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -588,7 +580,7 @@
                 android:background="@drawable/button_selector"
                 android:contentDescription="Gallery"
                 android:drawableTop="@drawable/ic_nav_gallery"
-                android:drawablePadding="-15dp"
+
                 android:elegantTextHeight="false"
                 android:freezesText="false"
                 android:text="Gallery"
@@ -655,5 +647,6 @@
         </LinearLayout>
 
     </LinearLayout>
+
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,9 +8,10 @@
     <LinearLayout
         android:id="@+id/topBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="90dp"
         android:layout_alignParentEnd="true"
-        android:background="@color/jade_dark">
+        android:background="@color/jade_dark"
+        >
 
         <Button
             android:id="@+id/flashBtn"
@@ -24,7 +25,6 @@
             android:textColor="@color/mint"
             android:textSize="12dp"
             android:contentDescription="Flash"/>
-
         <Button
             android:id="@+id/scanCenterBtn"
             android:layout_width="wrap_content"
@@ -37,7 +37,6 @@
             android:textColor="@color/mint"
             android:text="Scan Center"
             android:contentDescription="Scan Center Mode" />
-
         <!--<Button
             android:id="@+id/zoomBtn"
             android:layout_width="wrap_content"
@@ -66,13 +65,13 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_marginTop="10dp"
+
             android:background="@drawable/button_selector"
             android:drawableTop="@drawable/ic_screen_rotate"
             android:textSize="11dp"
             android:textColor="@color/mint"
             android:text="rotate"
             android:contentDescription="Rotate" />
-
         <Button
             android:id="@+id/bluetooth"
             android:layout_width="wrap_content"
@@ -86,9 +85,7 @@
             android:textSize="12dp"
             android:contentDescription="Bluetooth"/>
 
-
-
-    </LinearLayout>
+    </LinearLayout> <!--End of top bar-->
 
     <androidx.camera.view.PreviewView
         android:id="@+id/previewView"
@@ -110,7 +107,7 @@
             android:src="@drawable/ic_cross_with_border"
             android:layout_gravity="center"/>
 
-    </LinearLayout>
+    </LinearLayout> <!--End of centerLO-->
     <LinearLayout
         android:id="@+id/gridLayout"
         android:layout_width="match_parent"
@@ -268,15 +265,14 @@
                 android:contentDescription="Grid I"/>
         </LinearLayout>
 
-
-    </LinearLayout>
+    </LinearLayout> <!--End of grid Layout-->
     <LinearLayout
         android:id="@+id/zoomLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
-        android:layout_alignBottom="@+id/gridLayout"
+        android:layout_alignBottom="@+id/centerLayout"
         android:orientation="horizontal"
         android:gravity="center">
         <Button
@@ -289,7 +285,6 @@
             android:background="@drawable/button_selector"
             android:contentDescription="Zoom .05"
             />
-
         <Button
             android:id="@+id/zoom1_Btn"
             android:layout_width="80dp"
@@ -331,7 +326,7 @@
             android:background="@drawable/button_selector"
             android:contentDescription="Zoom 3"
             />
-    </LinearLayout>
+    </LinearLayout> <!-- End of zoom layout-->
 
     <LinearLayout
         android:id="@+id/bottomBar"
@@ -339,9 +334,8 @@
         android:layout_height="140dp"
         android:layout_alignBottom="@+id/previewView"
         android:background="@color/black_halftrans"
-        android:orientation="vertical">
-
-
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/centerLayout">
         <LinearLayout
             android:id="@+id/directionLayout"
             android:layout_width="wrap_content"
@@ -393,8 +387,7 @@
                 android:contentDescription="Right" />
 
 
-        </LinearLayout>
-
+        </LinearLayout> <!--End of direction layout. we are not using this-->
         <LinearLayout
             android:id="@+id/modeLayout"
             android:layout_width="wrap_content"
@@ -403,7 +396,10 @@
             android:layout_marginTop="1dp"
             android:layout_marginBottom="7dp"
             android:layout_weight="1"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            app:layout_constraintTop_toTopOf="@id/zoomLayout"
+            app:layout_constraintBottom_toTopOf="@id/bottomCaptureLayout"
+            >
 
             <Button
                 android:id="@+id/video_Btn"
@@ -426,7 +422,7 @@
                 android:layout_marginStart="15dp"
                 android:contentDescription="Photo Mode"
                 />
-        </LinearLayout>
+        </LinearLayout> <!--Enf od mode (PHOTO/VIDEO layout)-->
 
         <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
         We can later use this space to set the recording time -->
@@ -524,7 +520,8 @@
             android:layout_marginBottom="5dp"
             android:layout_weight="1"
             android:orientation="horizontal"
-            android:visibility="gone">
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@id/bottomBar">
 
             <TextView
                 android:id="@+id/modeTV"
@@ -575,6 +572,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/bottomCaptureLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -337,40 +337,237 @@
         android:background="@color/black_halftrans"
         android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/centerLayout">
-            <LinearLayout
-            android:id="@+id/modeLayout"
+        <LinearLayout
+        android:id="@+id/modeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="1dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toTopOf="@id/zoomLayout"
+        app:layout_constraintBottom_toTopOf="@id/bottomCaptureLayout"
+        >
+        <Button
+            android:id="@+id/video_Btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="VIDEO"
+            android:textAlignment="center"
+            android:textColor="#FFFFFF"
+            android:background="@drawable/button_selector_mode"
+            android:contentDescription="Video Mode"
+            />
+        <Button
+            android:id="@+id/photo_Btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="PHOTO"
+            android:textAlignment="center"
+            android:textColor="#FFFFFF"
+            android:background="@drawable/button_selector_mode"
+            android:layout_marginStart="15dp"
+            android:contentDescription="Photo Mode"
+            />
+    </LinearLayout> <!--Enf od mode (PHOTO/VIDEO layout)-->
+        <LinearLayout
+        android:id="@+id/directionLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="5dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <ImageButton
+            android:id="@+id/arrowBtn_Left"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="20dp"
+            android:background="@drawable/button_selector"
+            android:paddingHorizontal="@dimen/arrow_padding"
+            android:src="@drawable/ic_arrow"
+            android:contentDescription="Left"/>
+
+        <ImageButton
+            android:id="@+id/arrowBtn_Up"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:paddingHorizontal="@dimen/arrow_padding"
+            android:rotation="90"
+            android:src="@drawable/ic_arrow"
+            android:contentDescription="Up" />
+
+        <ImageButton
+            android:id="@+id/arrowBtn_Down"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:paddingHorizontal="@dimen/arrow_padding"
+            android:rotation="270"
+            android:src="@drawable/ic_arrow"
+            android:contentDescription="Down" />
+
+        <ImageButton
+            android:id="@+id/arrowBtn_Right"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:paddingHorizontal="@dimen/arrow_padding"
+            android:rotation="180"
+            android:src="@drawable/ic_arrow"
+            android:contentDescription="Right" />
+
+
+    </LinearLayout> <!--End of direction layout. we are not using this-->
+        <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
+        We can later use this space to set the recording time -->
+        <LinearLayout
+        android:id="@+id/recordingLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="1dp"
+        android:layout_marginBottom="7dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:visibility="gone">
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Recording in process"
+            android:textAlignment="center"
+            android:textColor="#FFFFFF"
+            android:contentDescription="Recording in process"
+            />
+    </LinearLayout>
+        <LinearLayout
+        android:id="@+id/levelLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="5dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/moveDir"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="1dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            app:layout_constraintTop_toTopOf="@id/zoomLayout"
-            app:layout_constraintBottom_toTopOf="@id/bottomCaptureLayout"
-            >
-            <Button
-                android:id="@+id/video_Btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="VIDEO"
-                android:textAlignment="center"
-                android:textColor="#FFFFFF"
-                android:background="@drawable/button_selector_mode"
-                android:contentDescription="Video Mode"
-                />
-            <Button
-                android:id="@+id/photo_Btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="PHOTO"
-                android:textAlignment="center"
-                android:textColor="#FFFFFF"
-                android:background="@drawable/button_selector_mode"
-                android:layout_marginStart="15dp"
-                android:contentDescription="Photo Mode"
-                />
-        </LinearLayout> <!--Enf od mode (PHOTO/VIDEO layout)-->
-            <LinearLayout
+            android:background="@drawable/button_selector"
+            android:text="LEFT"
+            android:textColor="@color/mint"
+            android:textSize="18dp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/moveLevel1"
+            android:layout_width="55dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:text="1"
+            android:textSize="20dp" />
+
+        <Button
+            android:id="@+id/moveLevel2"
+            android:layout_width="55dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:text="2"
+            android:textSize="20dp" />
+
+        <Button
+            android:id="@+id/moveLevel3"
+            android:layout_width="55dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:text="3"
+            android:textSize="20dp" />
+
+        <Button
+            android:id="@+id/moveLevel4"
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:background="@drawable/button_selector"
+            android:text="4"
+            android:textSize="20dp" />
+
+        <Button
+            android:id="@+id/moveDone"
+            android:layout_width="75dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/button_selector"
+            android:text="done"
+            android:textSize="13dp"
+            android:contentDescription="Done"
+            />
+
+
+    </LinearLayout>
+        <LinearLayout
+        android:id="@+id/orientationLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="5dp"
+        android:layout_weight="1"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toTopOf="@id/bottomBar"
+        android:visibility="gone"
+        >
+
+        <TextView
+            android:id="@+id/modeTV"
+            android:layout_width="65dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginRight="@dimen/direction_margin"
+            android:background="@drawable/button_selector"
+            android:text="ROTATE"
+            android:textColor="@color/mint"
+            android:textSize="15dp"
+            android:textStyle="bold" />
+
+
+        <Button
+            android:id="@+id/clockwiseBtn"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginRight="@dimen/direction_margin"
+            android:background="@drawable/button_selector"
+            android:drawableTop="@drawable/ic_clockwise"
+            android:text="clockwise"
+            android:contentDescription="clockwise"
+            android:textSize="0.1dp" />
+
+        <Button
+            android:id="@+id/anticlockwiseBtn"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginRight="@dimen/direction_margin"
+            android:background="@drawable/button_selector"
+            android:drawableTop="@drawable/ic_anticlockwise"
+            android:text="anticlockwise"
+            android:contentDescription="anticlockwise"
+            android:textSize="0.1dp" />
+
+        <Button
+            android:id="@+id/modeDone"
+            android:layout_width="75dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:background="@drawable/button_selector"
+            android:text="done"
+            android:textSize="13dp"
+            android:contentDescription="Done"/>
+    </LinearLayout>
+        <LinearLayout
             android:id="@+id/bottomCaptureLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -402,7 +599,9 @@
                 android:layout_marginLeft="30dp"
                 android:layout_marginRight="30dp"
                 android:contentDescription="@string/camera_photo_action"
-                android:src="@drawable/ic_nav_camera" />
+                android:src="@drawable/ic_nav_camera"
+                app:layout_constraintBottom_toBottomOf="@id/bottomBar"
+                />
 
             <!-- Ideally this button should be CENTERED and BIGGER than the others-->
 
@@ -451,205 +650,6 @@
                 -->
 
         </LinearLayout>
-
-            <LinearLayout
-            android:id="@+id/directionLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone">
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Left"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="20dp"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Left"/>
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Up"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="90"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Up" />
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Down"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="270"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Down" />
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Right"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="180"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Right" />
-
-
-        </LinearLayout> <!--End of direction layout. we are not using this-->
-            <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
-            We can later use this space to set the recording time -->
-            <LinearLayout
-            android:id="@+id/recordingLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="1dp"
-            android:layout_marginBottom="7dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone">
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Recording in process"
-                android:textAlignment="center"
-                android:textColor="#FFFFFF"
-                android:contentDescription="Recording in process"
-                />
-        </LinearLayout>
-            <LinearLayout
-            android:id="@+id/levelLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone">
-
-            <TextView
-                android:id="@+id/moveDir"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="@drawable/button_selector"
-                android:text="LEFT"
-                android:textColor="@color/mint"
-                android:textSize="18dp"
-                android:textStyle="bold" />
-
-            <Button
-                android:id="@+id/moveLevel1"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="1"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel2"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="2"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel3"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="3"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel4"
-                android:layout_width="50dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="4"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveDone"
-                android:layout_width="75dp"
-                android:layout_height="wrap_content"
-                android:background="@drawable/button_selector"
-                android:text="done"
-                android:textSize="13dp"
-                android:contentDescription="Done"
-                />
-
-
-        </LinearLayout>
-            <LinearLayout
-            android:id="@+id/orientationLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            app:layout_constraintTop_toTopOf="@id/bottomBar">
-
-            <TextView
-                android:id="@+id/modeTV"
-                android:layout_width="65dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:text="ROTATE"
-                android:textColor="@color/mint"
-                android:textSize="15dp"
-                android:textStyle="bold" />
-
-
-            <Button
-                android:id="@+id/clockwiseBtn"
-                android:layout_width="60dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:drawableTop="@drawable/ic_clockwise"
-                android:text="clockwise"
-                android:contentDescription="clockwise"
-                android:textSize="0.1dp" />
-
-            <Button
-                android:id="@+id/anticlockwiseBtn"
-                android:layout_width="60dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:drawableTop="@drawable/ic_anticlockwise"
-                android:text="anticlockwise"
-                android:contentDescription="anticlockwise"
-                android:textSize="0.1dp" />
-
-            <Button
-                android:id="@+id/modeDone"
-                android:layout_width="75dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="@drawable/button_selector"
-                android:text="done"
-                android:textSize="13dp"
-                android:contentDescription="Done"/>
-        </LinearLayout>
-
-
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
             android:contentDescription="Flash"/>
 
         <Button
-            android:id="@+id/centerBtn"
+            android:id="@+id/scanCenterBtn"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_marginTop="10dp"
@@ -35,8 +35,8 @@
             android:drawableTop="@drawable/ic_center"
             android:textSize="11dp"
             android:textColor="@color/mint"
-            android:text="Center"
-            android:contentDescription="Center" />
+            android:text="Scan Center"
+            android:contentDescription="Scan Center Mode" />
 
         <!--<Button
             android:id="@+id/zoomBtn"
@@ -49,6 +49,18 @@
             android:textColor="@color/mint"
             android:textSize="12dp" />
             -->
+        <Button
+            android:id="@+id/gridCenterBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp"
+            android:layout_weight="1"
+            android:background="@drawable/button_selector"
+            android:drawableTop="@drawable/ic_grid"
+            android:text="Grid Center"
+            android:textColor="@color/mint"
+            android:textSize="12dp"
+            android:contentDescription="Grid Center Mode"/>
         <Button
             android:id="@+id/rotateBtn"
             android:layout_width="wrap_content"
@@ -74,18 +86,7 @@
             android:textSize="12dp"
             android:contentDescription="Bluetooth"/>
 
-        <Button
-            android:id="@+id/settingsBtn"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_marginTop="10dp"
-            android:layout_weight="1"
-            android:background="@drawable/button_selector"
-            android:drawableTop="@drawable/ic_settings"
-            android:text="Settings"
-            android:textColor="@color/mint"
-            android:textSize="8dp"
-            android:contentDescription="Settings"/>
+
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -332,75 +332,22 @@
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"
         android:layout_height="140dp"
+        android:layout_alignParentBottom="true"
         android:layout_alignBottom="@+id/previewView"
         android:background="@color/black_halftrans"
         android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/centerLayout">
-        <LinearLayout
-            android:id="@+id/directionLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone">
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Left"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="20dp"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Left"/>
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Up"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="90"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Up" />
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Down"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="270"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Down" />
-
-            <ImageButton
-                android:id="@+id/arrowBtn_Right"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:paddingHorizontal="@dimen/arrow_padding"
-                android:rotation="180"
-                android:src="@drawable/ic_arrow"
-                android:contentDescription="Right" />
-
-
-        </LinearLayout> <!--End of direction layout. we are not using this-->
-        <LinearLayout
+            <LinearLayout
             android:id="@+id/modeLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginTop="1dp"
-            android:layout_marginBottom="7dp"
             android:layout_weight="1"
             android:orientation="horizontal"
             app:layout_constraintTop_toTopOf="@id/zoomLayout"
             app:layout_constraintBottom_toTopOf="@id/bottomCaptureLayout"
             >
-
             <Button
                 android:id="@+id/video_Btn"
                 android:layout_width="wrap_content"
@@ -423,155 +370,7 @@
                 android:contentDescription="Photo Mode"
                 />
         </LinearLayout> <!--Enf od mode (PHOTO/VIDEO layout)-->
-
-        <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
-        We can later use this space to set the recording time -->
-        <LinearLayout
-            android:id="@+id/recordingLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="1dp"
-            android:layout_marginBottom="7dp"
-            android:layout_weight="1"
-            android:orientation="horizontal">
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Recording in process"
-                android:textAlignment="center"
-                android:textColor="#FFFFFF"
-                android:contentDescription="Recording in process"
-                android:visibility="gone"
-                />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/levelLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone">
-
-            <TextView
-                android:id="@+id/moveDir"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="@drawable/button_selector"
-                android:text="LEFT"
-                android:textColor="@color/mint"
-                android:textSize="18dp"
-                android:textStyle="bold" />
-
-            <Button
-                android:id="@+id/moveLevel1"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="1"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel2"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="2"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel3"
-                android:layout_width="55dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="3"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveLevel4"
-                android:layout_width="50dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/button_selector"
-                android:text="4"
-                android:textSize="20dp" />
-
-            <Button
-                android:id="@+id/moveDone"
-                android:layout_width="75dp"
-                android:layout_height="wrap_content"
-                android:background="@drawable/button_selector"
-                android:text="done"
-                android:textSize="13dp"
-                android:contentDescription="Done"
-                />
-
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/orientationLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginBottom="5dp"
-            android:layout_weight="1"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            app:layout_constraintTop_toTopOf="@id/bottomBar">
-
-            <TextView
-                android:id="@+id/modeTV"
-                android:layout_width="65dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:text="ROTATE"
-                android:textColor="@color/mint"
-                android:textSize="15dp"
-                android:textStyle="bold" />
-
-
-            <Button
-                android:id="@+id/clockwiseBtn"
-                android:layout_width="60dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:drawableTop="@drawable/ic_clockwise"
-                android:text="clockwise"
-                android:contentDescription="clockwise"
-                android:textSize="0.1dp" />
-
-            <Button
-                android:id="@+id/anticlockwiseBtn"
-                android:layout_width="60dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginRight="@dimen/direction_margin"
-                android:background="@drawable/button_selector"
-                android:drawableTop="@drawable/ic_anticlockwise"
-                android:text="anticlockwise"
-                android:contentDescription="anticlockwise"
-                android:textSize="0.1dp" />
-
-            <Button
-                android:id="@+id/modeDone"
-                android:layout_width="75dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="@drawable/button_selector"
-                android:text="done"
-                android:textSize="13dp"
-                android:contentDescription="Done"/>
-        </LinearLayout>
-
-        <LinearLayout
+            <LinearLayout
             android:id="@+id/bottomCaptureLayout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -652,6 +451,205 @@
                 -->
 
         </LinearLayout>
+
+            <LinearLayout
+            android:id="@+id/directionLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="5dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:visibility="gone">
+
+            <ImageButton
+                android:id="@+id/arrowBtn_Left"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="20dp"
+                android:background="@drawable/button_selector"
+                android:paddingHorizontal="@dimen/arrow_padding"
+                android:src="@drawable/ic_arrow"
+                android:contentDescription="Left"/>
+
+            <ImageButton
+                android:id="@+id/arrowBtn_Up"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:paddingHorizontal="@dimen/arrow_padding"
+                android:rotation="90"
+                android:src="@drawable/ic_arrow"
+                android:contentDescription="Up" />
+
+            <ImageButton
+                android:id="@+id/arrowBtn_Down"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:paddingHorizontal="@dimen/arrow_padding"
+                android:rotation="270"
+                android:src="@drawable/ic_arrow"
+                android:contentDescription="Down" />
+
+            <ImageButton
+                android:id="@+id/arrowBtn_Right"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:paddingHorizontal="@dimen/arrow_padding"
+                android:rotation="180"
+                android:src="@drawable/ic_arrow"
+                android:contentDescription="Right" />
+
+
+        </LinearLayout> <!--End of direction layout. we are not using this-->
+            <!--This is just so that the gallery, capture anf flip buttons don't shift up during recording mode.
+            We can later use this space to set the recording time -->
+            <LinearLayout
+            android:id="@+id/recordingLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="1dp"
+            android:layout_marginBottom="7dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:visibility="gone">
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Recording in process"
+                android:textAlignment="center"
+                android:textColor="#FFFFFF"
+                android:contentDescription="Recording in process"
+                />
+        </LinearLayout>
+            <LinearLayout
+            android:id="@+id/levelLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="5dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/moveDir"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:background="@drawable/button_selector"
+                android:text="LEFT"
+                android:textColor="@color/mint"
+                android:textSize="18dp"
+                android:textStyle="bold" />
+
+            <Button
+                android:id="@+id/moveLevel1"
+                android:layout_width="55dp"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:text="1"
+                android:textSize="20dp" />
+
+            <Button
+                android:id="@+id/moveLevel2"
+                android:layout_width="55dp"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:text="2"
+                android:textSize="20dp" />
+
+            <Button
+                android:id="@+id/moveLevel3"
+                android:layout_width="55dp"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:text="3"
+                android:textSize="20dp" />
+
+            <Button
+                android:id="@+id/moveLevel4"
+                android:layout_width="50dp"
+                android:layout_height="match_parent"
+                android:background="@drawable/button_selector"
+                android:text="4"
+                android:textSize="20dp" />
+
+            <Button
+                android:id="@+id/moveDone"
+                android:layout_width="75dp"
+                android:layout_height="wrap_content"
+                android:background="@drawable/button_selector"
+                android:text="done"
+                android:textSize="13dp"
+                android:contentDescription="Done"
+                />
+
+
+        </LinearLayout>
+            <LinearLayout
+            android:id="@+id/orientationLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="5dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="@id/bottomBar">
+
+            <TextView
+                android:id="@+id/modeTV"
+                android:layout_width="65dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginRight="@dimen/direction_margin"
+                android:background="@drawable/button_selector"
+                android:text="ROTATE"
+                android:textColor="@color/mint"
+                android:textSize="15dp"
+                android:textStyle="bold" />
+
+
+            <Button
+                android:id="@+id/clockwiseBtn"
+                android:layout_width="60dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginRight="@dimen/direction_margin"
+                android:background="@drawable/button_selector"
+                android:drawableTop="@drawable/ic_clockwise"
+                android:text="clockwise"
+                android:contentDescription="clockwise"
+                android:textSize="0.1dp" />
+
+            <Button
+                android:id="@+id/anticlockwiseBtn"
+                android:layout_width="60dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginRight="@dimen/direction_margin"
+                android:background="@drawable/button_selector"
+                android:drawableTop="@drawable/ic_anticlockwise"
+                android:text="anticlockwise"
+                android:contentDescription="anticlockwise"
+                android:textSize="0.1dp" />
+
+            <Button
+                android:id="@+id/modeDone"
+                android:layout_width="75dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:background="@drawable/button_selector"
+                android:text="done"
+                android:textSize="13dp"
+                android:contentDescription="Done"/>
+        </LinearLayout>
+
+
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/splash_screen.xml
+++ b/app/src/main/res/layout/splash_screen.xml
@@ -35,7 +35,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif-thin"
-            android:text="@string/splash_group"
+            android:text="REAT Group 2"
             android:textColor="#B2B4BF"
             android:textSize="20dp"
             android:textStyle="bold"


### PR DESCRIPTION
-" center modes: Scan Center and Grid Center
-With Grid Center, hide all other buttons and just display the grid to select the desired center

Additionally
-When Rotate button is selected, the orientationLayout (clockwise, anticlockwise, done) appears and all other icons are hidden for time efficiency. When either of this buttons is pressed, it exits this panel and goes back to original view. Advantage: usually you only want one rotation, so it saves time of selecting the direction (for example: clockwise) and then selecting done (it can take some seconds for the selector to reach "done" button).